### PR TITLE
Fix useFetch.

### DIFF
--- a/src/components/common/search-input.tsx
+++ b/src/components/common/search-input.tsx
@@ -24,7 +24,9 @@ export const SearchInput: React.FC = () => {
     isActive ? inputRef?.current?.focus() : inputRef?.current?.blur();
   }, [isActive]);
 
-  const { result } = useFetch<{ data: CollectionItem[] | null }>(`/collections/search?query=${text}&limit=15`);
+  const { result } = useFetch<{ data: CollectionItem[] | null }>(
+    text ? `/collections/search?query=${text}&limit=15` : null
+  );
   const data = result?.data ?? [];
   const [selected, setSelected] = React.useState<CollectionItem | null>(null);
 

--- a/src/utils/apiUtils.ts
+++ b/src/utils/apiUtils.ts
@@ -157,9 +157,9 @@ interface useFetchParams {
   swrOptions?: SWRConfiguration<unknown> | undefined;
   [key: string]: unknown;
 }
-export function useFetch<T>(path: string, params: useFetchParams = {}) {
+export function useFetch<T>(path: string | null, params: useFetchParams = {}) {
   const queryStr = buildQueryString(params?.query);
-  const { data, error } = useSWR(`${path}${queryStr}`, swrFetch, params?.swrOptions || {});
+  const { data, error } = useSWR(path ? `${path}${queryStr}`: null, swrFetch, params?.swrOptions || {});
   return {
     result: error ? null : (data as T),
     isLoading: !error && !data,


### PR DESCRIPTION
Earlier implementation didn't allow us to [conditional fetching](https://swr.vercel.app/docs/conditional-fetching) because of which our components (such as collection search) made an extra network request when rendered.

This works:

```tsx
export function useFetch<T>(path: string | null, params: useFetchParams = {}) {
  const queryStr = buildQueryString(params?.query);
  const { data, error } = useSWR(path ? `${path}${queryStr}`: null, swrFetch, params?.swrOptions || {});
  return {
    result: error ? null : (data as T),
    isLoading: !error && !data,
    isError: !!error,
    error
  };
}
```