### PR TITLE
Make OrderDrawer accessible on every page

### DIFF
--- a/pages/collection/[name]/index.tsx
+++ b/pages/collection/[name]/index.tsx
@@ -12,13 +12,12 @@ import { CommunityRightPanel } from 'src/components/collection/community-right-p
 import { AiOutlineCheck } from 'react-icons/ai';
 import { AvatarImage } from 'src/components/collection/avatar-image';
 import { useOrderContext } from 'src/utils/context/OrderContext';
-import { OrderDrawer } from 'src/components/market/order-drawer/order-drawer';
 import ContentLoader from 'react-content-loader';
 import { iconButtonStyle } from 'src/utils/ui-constants';
 import { OrderbookContainer } from 'src/components/market/orderbook-list';
 
 const CollectionPage = () => {
-  const { orderDrawerOpen, setOrderDrawerOpen, addCartItem } = useOrderContext();
+  const { addCartItem } = useOrderContext();
   const router = useRouter();
   const {
     query: { name }
@@ -195,7 +194,7 @@ const CollectionPage = () => {
         </main>
       </div>
 
-      <OrderDrawer open={orderDrawerOpen} onClose={() => setOrderDrawerOpen(false)} />
+      {/* <OrderDrawer open={orderDrawerOpen} onClose={() => setOrderDrawerOpen(false)} /> */}
     </PageBox>
   );
 };

--- a/pages/marketplace/index.tsx
+++ b/pages/marketplace/index.tsx
@@ -1,10 +1,7 @@
 import { ToggleTab, useToggleTab, Spacer, PageBox } from 'src/components/common';
-import { OrderDrawer } from 'src/components/market';
-import { useOrderContext } from 'src/utils/context/OrderContext';
 import { OrderbookContainer } from 'src/components/market/orderbook-list';
 
 const MarketplacePage = () => {
-  const { orderDrawerOpen, setOrderDrawerOpen } = useOrderContext();
   const { options, onChange, selected } = useToggleTab(['Orderbook', 'Buy', 'Sell'], 'Orderbook');
 
   const contents = (
@@ -20,7 +17,7 @@ const MarketplacePage = () => {
 
   return (
     <PageBox title="Marketplace">
-      <OrderDrawer open={orderDrawerOpen} onClose={() => setOrderDrawerOpen(false)} />
+      {/* <OrderDrawer open={orderDrawerOpen} onClose={() => setOrderDrawerOpen(false)} /> */}
 
       <div>{contents}</div>
     </PageBox>

--- a/src/components/common/page-box.tsx
+++ b/src/components/common/page-box.tsx
@@ -1,6 +1,8 @@
 import { useRouter } from 'next/router';
 import React from 'react';
 import { Navbar, Spacer, Header } from 'src/components/common';
+import { useOrderContext } from 'src/utils/context/OrderContext';
+import { OrderDrawer } from '../market';
 
 // used in the Header
 export const pageStyles = 'mx-auto desktop:w-5/6 desktop-sm:w-[95%] tabloid:w-[95%] mobile:w-[98%]';
@@ -22,6 +24,8 @@ export const PageBox = ({
   className = '',
   rightToolbar
 }: Props): JSX.Element => {
+  const { orderDrawerOpen, setOrderDrawerOpen } = useOrderContext();
+
   return (
     <>
       <div className="transition w-[100vw] h-[100vh] overflow-y-auto overflow-x-hidden justify-items-center">
@@ -31,7 +35,10 @@ export const PageBox = ({
           <div className={`transition ${fullWidth ? 'w-full' : pageStyles}`}>
             {showTitle ? <PageHeader title={title} rightToolbar={rightToolbar} /> : null}
 
-            <div className={`w-full ${className}`}>{children}</div>
+            <div className={`w-full ${className}`}>
+              {children}
+              <OrderDrawer open={orderDrawerOpen} onClose={() => setOrderDrawerOpen(false)} />
+            </div>
 
             {/* allows scroll so items aren't at the bottom of the screen */}
             <div style={{ height: 300 }} />


### PR DESCRIPTION
Allow OrderDrawer to be accessible on every page by clicking on the ShoppingCart icon.