### PR TITLE
Add most recently voted filter, change carousel order to most recent by default

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@amit.rajput/react-linkify": "^1.0.4",
         "@headlessui/react": "^1.7.3",
         "@heroicons/react": "^1.0.6",
-        "@infinityxyz/lib-frontend": "^1.261.0",
+        "@infinityxyz/lib-frontend": "^1.262.0",
         "@next/bundle-analyzer": "^12.3.1",
         "@tailwindcss/aspect-ratio": "^0.4.2",
         "@tailwindcss/typography": "^0.5.7",
@@ -4126,9 +4126,9 @@
       "dev": true
     },
     "node_modules/@infinityxyz/lib-frontend": {
-      "version": "1.261.0",
-      "resolved": "https://registry.npmjs.org/@infinityxyz/lib-frontend/-/lib-frontend-1.261.0.tgz",
-      "integrity": "sha512-6ZoDFl5Ll3a90Z3nhG38++OqxynuNC6QweL228jA3Swz7IAVbiweV45LS5j8NNSqfguV41czS/4adO7Y2GhU3w==",
+      "version": "1.262.0",
+      "resolved": "https://registry.npmjs.org/@infinityxyz/lib-frontend/-/lib-frontend-1.262.0.tgz",
+      "integrity": "sha512-GyqLjySXiGIKG8MWzjF5L9VlzJJNnoU78HBqphHjexUk5ROjZONSmK27R4Gk/Cq285upYaQRjGNx8OUL5++M7A==",
       "dependencies": {
         "@nestjs/swagger": "^6.1.2",
         "ethers": "^5.6.4"
@@ -32531,9 +32531,9 @@
       "dev": true
     },
     "@infinityxyz/lib-frontend": {
-      "version": "1.261.0",
-      "resolved": "https://registry.npmjs.org/@infinityxyz/lib-frontend/-/lib-frontend-1.261.0.tgz",
-      "integrity": "sha512-6ZoDFl5Ll3a90Z3nhG38++OqxynuNC6QweL228jA3Swz7IAVbiweV45LS5j8NNSqfguV41czS/4adO7Y2GhU3w==",
+      "version": "1.262.0",
+      "resolved": "https://registry.npmjs.org/@infinityxyz/lib-frontend/-/lib-frontend-1.262.0.tgz",
+      "integrity": "sha512-GyqLjySXiGIKG8MWzjF5L9VlzJJNnoU78HBqphHjexUk5ROjZONSmK27R4Gk/Cq285upYaQRjGNx8OUL5++M7A==",
       "requires": {
         "@nestjs/swagger": "^6.1.2",
         "ethers": "^5.6.4"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@amit.rajput/react-linkify": "^1.0.4",
     "@headlessui/react": "^1.7.3",
     "@heroicons/react": "^1.0.6",
-    "@infinityxyz/lib-frontend": "^1.261.0",
+    "@infinityxyz/lib-frontend": "^1.262.0",
     "@next/bundle-analyzer": "^12.3.1",
     "@tailwindcss/aspect-ratio": "^0.4.2",
     "@tailwindcss/typography": "^0.5.7",

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -30,8 +30,8 @@ const HomePage = () => {
 
   return (
     <PageBox title="Home" showTitle={false} footer={<StartFooter />}>
-      {titleHeader('Curated Collections', 'mt-6', '/curated?tab=All+Curated')}
-      <AllCuratedStart orderBy={CuratedCollectionsOrderBy.Votes} />
+      {titleHeader('Recently Curated Collections', 'mt-6', '/curated?tab=All+Curated')}
+      <AllCuratedStart orderBy={CuratedCollectionsOrderBy.Timestamp} />
 
       {titleHeader('Rewards', 'mt-10', '/rewards?tab=Global+Rewards')}
       <GlobalRewards showCount={1} />

--- a/src/components/curation/sort.tsx
+++ b/src/components/curation/sort.tsx
@@ -37,6 +37,16 @@ export const Sort: React.FC<Props> = ({ onClick, order }) => {
           break;
       }
       break;
+    case CuratedCollectionsOrderBy.Timestamp:
+      switch (order.direction) {
+        case OrderDirection.Ascending:
+          label = 'Least recent';
+          break;
+        case OrderDirection.Descending:
+          label = 'Most recent';
+          break;
+      }
+      break;
   }
 
   return (
@@ -50,13 +60,13 @@ export const Sort: React.FC<Props> = ({ onClick, order }) => {
           onClick: () => onClick({ orderBy: CuratedCollectionsOrderBy.Votes, direction: OrderDirection.Descending })
         },
         {
+          label: 'Most recent',
+          onClick: () => onClick({ orderBy: CuratedCollectionsOrderBy.Timestamp, direction: OrderDirection.Descending })
+        },
+        {
           label: 'APR: High to low',
           onClick: () => onClick({ orderBy: CuratedCollectionsOrderBy.Apr, direction: OrderDirection.Descending })
         },
-        {
-          label: 'APR: Low to high',
-          onClick: () => onClick({ orderBy: CuratedCollectionsOrderBy.Apr, direction: OrderDirection.Ascending })
-        }
       ]}
     />
   );


### PR DESCRIPTION
At the moment the top 10 curated collections (by most votes) are shown in the carousel. With this change, the 10 most recent curated collections are shown instead. It's a nice improvement for new users who are clueless on what to curate.

Only collections that have a minimum of 5% of the total votes from the top collection (i.e the collection w/ the most amount of curators) will be included in the carousel. For example, if the top collection has 100 votes, a collection must have at least 5 and at most 100 votes for it to be considered in the carousel. That way we can scale along as the amount of curators grows and avoid showcasing shitty collections with only ~1 vote in the carousel.

Screenshots:

<img width="919" alt="image" src="https://user-images.githubusercontent.com/30344294/201140362-2640656b-0017-4c8d-9f43-d011e427e126.png">

<img width="189" alt="image" src="https://user-images.githubusercontent.com/30344294/201142090-f5cd3d3e-5975-40d1-b72f-445314af4ce1.png">
